### PR TITLE
release only a ZIP of the source, no tarballs

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -33,7 +33,7 @@ builds:
   binary: '{{ .ProjectName }}_{{ .Version }}'
 archives:
 - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
-  # Removed deprecated 'format' field
+  format: zip
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256


### PR DESCRIPTION
otherwise the TF registry might ingest the tarball and then offer it as download to clients. Those clients will then complain that what they got is not a ZIP.