### PR TITLE
chore: bump the github-actions group across 1 directory with 5 updates

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,8 +14,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-    - uses: actions/setup-go@v6.1.0
+    - uses: actions/setup-go@v6.4.0
       with:
         go-version: '1.24'
-    - uses: hashicorp/setup-terraform@v3
+    - uses: hashicorp/setup-terraform@v4
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,18 +19,18 @@ jobs:
         # For GoReleaser to work, we need to fetch all tags and the full history
         fetch-depth: 0
         fetch-tags: true
-    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: go.mod
         cache: true
     - name: Import GPG key
       id: import_gpg
-      uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6.3.0
+      uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd  # v7.0.0
       with:
         gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
         passphrase: ' ${{ secrets.PASSPHRASE }}'
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6.4.0
+      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # v7.0.0
       with:
         version: latest
         args: release --clean

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,13 +14,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-    - uses: actions/setup-go@v6.1.0
+    - uses: actions/setup-go@v6.4.0
       with:
         go-version: '1.24'
     - name: Unit tests (with coverage)
       run: make test-coverage
     - name: Upload coverage to Codecov (unit)
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: ./coverage/unit/coverage.out
         flags: unit
@@ -32,7 +32,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-    - uses: actions/setup-go@v6.1.0
+    - uses: actions/setup-go@v6.4.0
       with:
         go-version: '1.24'
     - name: Acceptance tests (with coverage)
@@ -48,7 +48,7 @@ jobs:
         SONARCLOUD_QUALITY_GATE_NAME: ${{ secrets.ACC_TEST_SONARCLOUD_QUALITY_GATE_NAME }}
         SONARCLOUD_QUALITY_GATE_ID: ${{ secrets.ACC_TEST_SONARCLOUD_QUALITY_GATE_ID }}
     - name: Upload coverage to Codecov (acceptance)
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: ./coverage/acceptance/coverage.out
         flags: acceptance


### PR DESCRIPTION
Bumps the github-actions group with 5 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [actions/setup-go](https://github.com/actions/setup-go) | `6.1.0` | `6.4.0` | | [hashicorp/setup-terraform](https://github.com/hashicorp/setup-terraform) | `3` | `4` | | [crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg) | `6.3.0` | `7.0.0` | | [goreleaser/goreleaser-action](https://github.com/goreleaser/goreleaser-action) | `6.4.0` | `7.0.0` | | [codecov/codecov-action](https://github.com/codecov/codecov-action) | `5` | `6` |



Updates `actions/setup-go` from 6.1.0 to 6.4.0
- [Release notes](https://github.com/actions/setup-go/releases)
- [Commits](https://github.com/actions/setup-go/compare/v6.1.0...v6.4.0)

Updates `hashicorp/setup-terraform` from 3 to 4
- [Release notes](https://github.com/hashicorp/setup-terraform/releases)
- [Changelog](https://github.com/hashicorp/setup-terraform/blob/main/CHANGELOG.md)
- [Commits](https://github.com/hashicorp/setup-terraform/compare/v3...v4)

Updates `crazy-max/ghaction-import-gpg` from 6.3.0 to 7.0.0
- [Release notes](https://github.com/crazy-max/ghaction-import-gpg/releases)
- [Commits](https://github.com/crazy-max/ghaction-import-gpg/compare/e89d40939c28e39f97cf32126055eeae86ba74ec...2dc316deee8e90f13e1a351ab510b4d5bc0c82cd)

Updates `goreleaser/goreleaser-action` from 6.4.0 to 7.0.0
- [Release notes](https://github.com/goreleaser/goreleaser-action/releases)
- [Commits](https://github.com/goreleaser/goreleaser-action/compare/e435ccd777264be153ace6237001ef4d979d3a7a...ec59f474b9834571250b370d4735c50f8e2d1e29)

Updates `codecov/codecov-action` from 5 to 6
- [Release notes](https://github.com/codecov/codecov-action/releases)
- [Changelog](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/codecov/codecov-action/compare/v5...v6)

---
updated-dependencies:
- dependency-name: actions/setup-go dependency-version: 6.4.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: github-actions
- dependency-name: hashicorp/setup-terraform dependency-version: '4' dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions
- dependency-name: crazy-max/ghaction-import-gpg dependency-version: 7.0.0 dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions
- dependency-name: goreleaser/goreleaser-action dependency-version: 7.0.0 dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions
- dependency-name: codecov/codecov-action dependency-version: '6' dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions ...